### PR TITLE
Harden auth sessions and sanitize error messages

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -3,7 +3,7 @@
 package main
 
 import (
-	"crypto/sha256"
+	"crypto/rand"
 	"crypto/subtle"
 	"encoding/hex"
 	"fmt"
@@ -19,11 +19,12 @@ import (
 const (
 	sessionCookieName = "spindle_session"
 	sessionKVPrefix   = "session:"
+	sessionMaxAgeS    = 7 * 24 * 3600 // 7 days in seconds
 
 	// Rate limiting: lock out after maxLoginAttempts failures within the window.
-	rateLimitKVKey    = "login_attempts"
-	maxLoginAttempts  = 5
-	lockoutDurationS  = 900 // 15 minutes in seconds
+	rateLimitKVKey   = "login_attempts"
+	maxLoginAttempts = 5
+	lockoutDurationS = 900 // 15 minutes in seconds
 )
 
 // getConfiguredPassword returns the password from Spin variables.
@@ -36,17 +37,17 @@ func getConfiguredPassword() string {
 	return pw
 }
 
-// generateSessionToken creates a token from the password and current time.
-// Using the timestamp makes each login produce a distinct token, so
-// logging out actually invalidates the old session.
-func generateSessionToken(password string) string {
-	ts := time.Now().UnixNano()
-	data := fmt.Sprintf("spindle-session:%s:%d", password, ts)
-	h := sha256.Sum256([]byte(data))
-	return hex.EncodeToString(h[:])
+// generateSessionToken creates a cryptographically random token.
+func generateSessionToken() string {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		// Fallback should never happen — crypto/rand uses OS entropy.
+		panic("crypto/rand failed: " + err.Error())
+	}
+	return hex.EncodeToString(b)
 }
 
-// storeSession saves a session token in the KV store.
+// storeSession saves a session token in the KV store with a creation timestamp.
 func storeSession(token string) error {
 	store, err := kv.OpenStore("default")
 	if err != nil {
@@ -54,10 +55,12 @@ func storeSession(token string) error {
 	}
 	defer store.Close()
 
-	return store.Set(sessionKVPrefix+token, []byte("1"))
+	// Store the creation time so we can enforce expiration.
+	createdAt := strconv.FormatInt(time.Now().Unix(), 10)
+	return store.Set(sessionKVPrefix+token, []byte(createdAt))
 }
 
-// validateSession checks if a session token exists in the KV store.
+// validateSession checks if a session token exists and hasn't expired.
 func validateSession(token string) bool {
 	store, err := kv.OpenStore("default")
 	if err != nil {
@@ -65,11 +68,22 @@ func validateSession(token string) bool {
 	}
 	defer store.Close()
 
-	exists, err := store.Exists(sessionKVPrefix + token)
+	data, err := store.Get(sessionKVPrefix + token)
 	if err != nil {
 		return false
 	}
-	return exists
+
+	createdAt, err := strconv.ParseInt(string(data), 10, 64)
+	if err != nil {
+		return false
+	}
+
+	if time.Now().Unix()-createdAt > int64(sessionMaxAgeS) {
+		// Expired — clean up
+		store.Delete(sessionKVPrefix + token)
+		return false
+	}
+	return true
 }
 
 // --- Rate limiting ---
@@ -245,7 +259,7 @@ func loginHandler(w http.ResponseWriter, r *http.Request) {
 	resetLoginAttempts()
 
 	// Create session
-	token := generateSessionToken(password)
+	token := generateSessionToken()
 	if err := storeSession(token); err != nil {
 		writeHTML(w, http.StatusInternalServerError, "Failed to create session")
 		return

--- a/main.go
+++ b/main.go
@@ -115,7 +115,7 @@ func previewHandler(w http.ResponseWriter, r *http.Request) {
 
 	feed, err := fetchFeed(url)
 	if err != nil {
-		writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "failed to fetch feed"})
 		return
 	}
 
@@ -135,7 +135,7 @@ func createFeedHandler(w http.ResponseWriter, r *http.Request) {
 
 	db, err := openDB()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 		return
 	}
 
@@ -147,7 +147,7 @@ func createFeedHandler(w http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
-		writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "failed to fetch feed"})
 		return
 	}
 
@@ -157,13 +157,13 @@ func createFeedHandler(w http.ResponseWriter, r *http.Request) {
 func listFeedsHandler(w http.ResponseWriter, r *http.Request) {
 	db, err := openDB()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 		return
 	}
 
 	feeds, err := listFeeds(db)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 		return
 	}
 
@@ -182,7 +182,7 @@ func getFeedHandler(w http.ResponseWriter, r *http.Request, path string) {
 
 	db, err := openDB()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 		return
 	}
 
@@ -204,12 +204,12 @@ func deleteFeedHandler(w http.ResponseWriter, r *http.Request, path string) {
 
 	db, err := openDB()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 		return
 	}
 
 	if err := deleteFeed(db, id); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 		return
 	}
 
@@ -227,7 +227,7 @@ func refreshFeedHandler(w http.ResponseWriter, r *http.Request, path string) {
 
 	db, err := openDB()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 		return
 	}
 
@@ -239,7 +239,7 @@ func refreshFeedHandler(w http.ResponseWriter, r *http.Request, path string) {
 
 	added, err := refreshFeed(db, feed)
 	if err != nil {
-		writeJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusBadGateway, map[string]string{"error": "failed to fetch feed"})
 		return
 	}
 
@@ -254,13 +254,13 @@ func refreshFeedHandler(w http.ResponseWriter, r *http.Request, path string) {
 func refreshAllHandler(w http.ResponseWriter, r *http.Request) {
 	db, err := openDB()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 		return
 	}
 
 	feeds, err := listFeeds(db)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 		return
 	}
 
@@ -288,7 +288,7 @@ func refreshAllHandler(w http.ResponseWriter, r *http.Request) {
 func listArticlesHandler(w http.ResponseWriter, r *http.Request) {
 	db, err := openDB()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 		return
 	}
 
@@ -308,7 +308,7 @@ func listArticlesHandler(w http.ResponseWriter, r *http.Request) {
 
 	articles, err := listArticles(db, feedID, isRead, limit, offset)
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 		return
 	}
 
@@ -329,7 +329,7 @@ func getArticleHandler(w http.ResponseWriter, r *http.Request, path string) {
 
 	db, err := openDB()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 		return
 	}
 
@@ -361,12 +361,12 @@ func updateArticleHandler(w http.ResponseWriter, r *http.Request, path string) {
 
 	db, err := openDB()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 		return
 	}
 
 	if err := updateArticleRead(db, id, req.IsRead); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 		return
 	}
 
@@ -384,14 +384,14 @@ func updateArticleHandler(w http.ResponseWriter, r *http.Request, path string) {
 func markAllReadHandler(w http.ResponseWriter, r *http.Request) {
 	db, err := openDB()
 	if err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 		return
 	}
 
 	feedID, _ := strconv.ParseInt(r.URL.Query().Get("feed_id"), 10, 64)
 
 	if err := markAllRead(db, feedID); err != nil {
-		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": err.Error()})
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal error"})
 		return
 	}
 

--- a/ui.go
+++ b/ui.go
@@ -91,7 +91,7 @@ func uiCreateFeedHandler(w http.ResponseWriter, r *http.Request) {
 			uiFeedsListHandler(w, r)
 			return
 		}
-		writeHTML(w, http.StatusBadGateway, fmt.Sprintf(`<p class="error">%s</p>`, escapeHTML(err.Error())))
+		writeHTML(w, http.StatusBadGateway, `<p class="error">Failed to fetch feed</p>`)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- **Session tokens**: Replaced predictable timestamp-based generation with `crypto/rand` (32 random bytes). Each login now produces a cryptographically unique token.
- **Session expiration**: Sessions now expire after 7 days. Creation timestamp stored in KV; validated on each request.
- **Error message sanitization**: All `err.Error()` responses replaced with generic messages (`"internal error"`, `"failed to fetch feed"`) to prevent leaking internal details (DB errors, file paths, etc.) to clients.

## Test plan
- [x] `spin build` succeeds
- [x] `go test ./...` passes
- [x] Auth flow: login, authenticated requests, logout all work
- [x] Tokens are unique across logins (crypto/rand verified)
- [x] Session isolation: logging out one session doesn't affect another
- [x] Error responses return generic messages, no internal details

🤖 Generated with [Claude Code](https://claude.com/claude-code)