### PR TITLE
Conditional logout button and auth/deploy docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ Two Spin components routed by URL prefix:
 All routing within the API component is done manually in Go (`router` function in `main.go`) because third-party routers like httprouter can cause WASM traps at init time.
 
 - `main.go` — HTTP handler entry point + routing (JSON API handlers)
+- `auth.go` — Password authentication, session management (KV store), rate limiting
 - `ui.go` — HTMX HTML fragment handlers (return HTML, not JSON)
 - `models.go` — Data types: XML parsing structs (RSS/Atom) and normalized Feed/Article types
 - `feeds.go` — Feed fetching via outbound HTTP + XML parsing
@@ -63,10 +64,33 @@ Spin components are **stateless**: each HTTP request creates a fresh WASM instan
 - **No LastInsertId/RowsAffected** — Spin's SQLite driver doesn't support these; query back after inserts
 - **No transactions** — each SQL statement is independent
 
+## Authentication
+
+Optional password protection via Spin variables. When `password` is set, all endpoints except `/api/health` and `/api/login` require a valid session cookie.
+
+- **Disabled by default** — if `password` variable is empty or unset, all endpoints are open
+- **Sessions** stored in KV store with 7-day expiration, tokens generated via `crypto/rand`
+- **Rate limiting** — 5 failed login attempts triggers a 15-minute lockout
+- To enable locally: `spin up --variable password=yourpass`
+- To enable in cloud: `spin cloud variables set --app spindle password=yourpass`
+
+## Deployment (Fermyon Cloud)
+
+```bash
+spin cloud login                                          # Interactive browser auth (one-time)
+spin build && spin cloud deploy                           # Build and deploy
+spin cloud variables set --app spindle password=<pass>    # Set password (no redeploy needed)
+```
+
+Variables take effect immediately — no redeploy required after changing them.
+
 ## API Endpoints
 
 ```
 GET    /api/health
+GET    /api/login                              Login page (redirects to / if no password set)
+POST   /api/login                              Authenticate (form: password=...)
+POST   /api/logout                             Clear session
 POST   /api/feeds                              Subscribe (body: {"url": "..."})
 GET    /api/feeds                              List subscriptions
 GET    /api/feeds/:id                          Get feed
@@ -93,6 +117,7 @@ Three educational guides live in `guides/`. They trace RSS, Go, and WebAssembly 
 ### HTMX UI Endpoints (return HTML fragments)
 
 ```
+GET    /api/ui/auth-status                     Logout button (if auth enabled) or empty
 GET    /api/ui/feeds                           Feed sidebar list
 POST   /api/ui/feeds                           Subscribe (form-encoded)
 DELETE /api/ui/feeds/:id                       Unsubscribe + return updated list

--- a/main.go
+++ b/main.go
@@ -44,6 +44,8 @@ func router(w http.ResponseWriter, r *http.Request) {
 	// --- UI (HTMX) endpoints ---
 	// These return HTML fragments for HTMX to swap into the page.
 	// Must be matched before the JSON API routes since they share /api/feeds prefix.
+	case method == http.MethodGet && path == "/api/ui/auth-status":
+		uiAuthStatusHandler(w, r)
 	case method == http.MethodGet && path == "/api/ui/feeds":
 		uiFeedsListHandler(w, r)
 	case method == http.MethodPost && path == "/api/ui/feeds":

--- a/static/index.html
+++ b/static/index.html
@@ -14,9 +14,7 @@
                 <h1>Spindle</h1>
                 <span class="subtitle">Spin + WASM RSS Reader</span>
             </div>
-            <form method="POST" action="/api/logout" class="logout-form">
-                <button type="submit" class="btn-secondary">Logout</button>
-            </form>
+            <div hx-get="/api/ui/auth-status" hx-trigger="load" hx-swap="innerHTML"></div>
         </header>
 
         <div class="layout">

--- a/ui.go
+++ b/ui.go
@@ -274,6 +274,16 @@ func renderOneArticle(a *StoreArticle) string {
 	return b.String()
 }
 
+// uiAuthStatusHandler returns the logout button if auth is enabled, empty otherwise.
+// GET /api/ui/auth-status
+func uiAuthStatusHandler(w http.ResponseWriter, r *http.Request) {
+	if getConfiguredPassword() == "" {
+		writeHTML(w, http.StatusOK, "")
+		return
+	}
+	writeHTML(w, http.StatusOK, `<form method="POST" action="/api/logout" class="logout-form"><button type="submit" class="btn-secondary">Logout</button></form>`)
+}
+
 func writeHTML(w http.ResponseWriter, status int, html string) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(status)


### PR DESCRIPTION
## Summary
- **Conditional logout button**: Replaced the static logout form in `index.html` with an HTMX-loaded `/api/ui/auth-status` endpoint. Returns the logout button only when a password is configured; empty otherwise.
- **CLAUDE.md updates**: Documented authentication setup (local + cloud), Fermyon Cloud deployment steps, and new auth/UI endpoints.

## Test plan
- [x] `spin build` succeeds
- [x] `go test ./...` passes
- [x] No password mode: logout button hidden, all endpoints open
- [x] Password mode: logout button visible, login required
- [ ] Redeploy to Fermyon Cloud and verify logout button behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)