### PR TITLE
Add feedback for refresh-all: toast notification and loading state

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -51,6 +51,7 @@
                         <button hx-post="/api/ui/feeds/refresh-all"
                                 hx-target="#article-list"
                                 hx-swap="innerHTML"
+                                hx-disabled-elt="this"
                                 class="btn-secondary">
                             Refresh
                         </button>

--- a/static/style.css
+++ b/static/style.css
@@ -330,6 +330,27 @@ header h1 {
 .htmx-request .htmx-indicator,
 .htmx-request.htmx-indicator { display: inline; }
 
+/* Refresh toast notification */
+@keyframes toastFadeOut {
+    0%, 70% { opacity: 1; max-height: 60px; margin-bottom: 0.5rem; padding: 0.5rem 1rem; }
+    100%     { opacity: 0; max-height: 0; margin: 0; padding: 0; overflow: hidden; }
+}
+
+.refresh-toast {
+    background: var(--teal-dim);
+    color: var(--teal);
+    border: 1px solid rgba(45, 212, 191, 0.25);
+    border-radius: 6px;
+    font-size: 0.82rem;
+    animation: toastFadeOut 3s ease forwards;
+    pointer-events: none;
+}
+
+.btn-secondary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
 /* Login page */
 .login-container {
     max-width: 340px;

--- a/ui.go
+++ b/ui.go
@@ -161,11 +161,37 @@ func uiRefreshAllHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	totalNew := 0
 	for i := range feeds {
-		refreshFeed(db, &feeds[i])
+		n, _ := refreshFeed(db, &feeds[i])
+		totalNew += n
 	}
 
-	renderArticleList(w, db, 0)
+	articles, err := listArticles(db, 0, -1, 100, 0)
+	if err != nil {
+		writeHTML(w, http.StatusInternalServerError, `<p class="error">Failed to load articles</p>`)
+		return
+	}
+
+	var b strings.Builder
+
+	if totalNew == 1 {
+		b.WriteString(`<div class="refresh-toast">1 new article</div>`)
+	} else if totalNew > 1 {
+		fmt.Fprintf(&b, `<div class="refresh-toast">%d new articles</div>`, totalNew)
+	} else {
+		b.WriteString(`<div class="refresh-toast">Already up to date</div>`)
+	}
+
+	if len(articles) == 0 {
+		b.WriteString(`<p class="empty">No articles yet. Subscribe to a feed and refresh!</p>`)
+	} else {
+		for i := range articles {
+			b.WriteString(renderOneArticle(&articles[i]))
+		}
+	}
+
+	writeHTML(w, http.StatusOK, b.String())
 }
 
 // uiArticlesHandler returns the article list HTML.


### PR DESCRIPTION
- Collect new article count from all refreshFeed calls (was discarded)
- Prepend an auto-dismissing toast showing "N new articles" or "Already
  up to date" to the article list response
- Add hx-disabled-elt to the Refresh button so it disables during the
  in-flight request (visual cue that something is happening)
- Add CSS keyframe animation for the toast (fades out and collapses
  after 3s, pure CSS, no JS)
- Style disabled .btn-secondary with reduced opacity

https://claude.ai/code/session_01QxK4FLwjo738FaS242sk1d