### PR TITLE
Folders feature + migration fix + pre-commit hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git commit*)",
+            "command": "go test ./... && go vet ./... || echo '{\"continue\":false,\"stopReason\":\"go test or go vet failed — fix before committing\"}'",
+            "statusMessage": "Running tests before commit...",
+            "timeout": 60
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/folders_test.go
+++ b/folders_test.go
@@ -157,8 +157,8 @@ func TestRenderFeedList_FolderRefreshButton(t *testing.T) {
 	feeds := []StoreFeed{{ID: 1, Title: "Nature", FolderID: 7}}
 	html := renderFeedList(feeds, folders)
 
-	if !containsStr(html, `/api/ui/folders/7/refresh`) {
-		t.Error("expected folder refresh endpoint in folder header")
+	if !containsStr(html, `refreshFolderFeeds(this, 7)`) {
+		t.Error("expected refreshFolderFeeds JS call in folder header refresh button")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -64,8 +64,6 @@ func router(w http.ResponseWriter, r *http.Request) {
 		uiToggleReadHandler(w, r, path)
 	case method == http.MethodDelete && strings.HasPrefix(path, "/api/ui/folders/"):
 		uiDeleteFolderHandler(w, r, path)
-	case method == http.MethodPost && strings.HasSuffix(path, "/refresh") && strings.HasPrefix(path, "/api/ui/folders/"):
-		uiRefreshFolderHandler(w, r, path)
 	case method == http.MethodPost && strings.HasSuffix(path, "/folder") && strings.HasPrefix(path, "/api/ui/feeds/"):
 		uiMoveFeedFolderHandler(w, r, path)
 

--- a/render.go
+++ b/render.go
@@ -60,9 +60,7 @@ func renderFeedList(feeds []StoreFeed, folders []StoreFolder) string {
 			`onclick="document.getElementById('content-title').textContent='%s'">%s</span>`+
 			`<span class="folder-header-actions">`+
 			`<button class="btn-icon" `+
-			`hx-post="/api/ui/folders/%d/refresh" `+
-			`hx-target="#article-list" hx-swap="innerHTML" `+
-			`hx-disabled-elt="this" `+
+			`onclick="refreshFolderFeeds(this, %d)" `+
 			`title="Refresh folder">&#8635;</button>`+
 			`<button class="btn-icon folder-delete" `+
 			`hx-delete="/api/ui/folders/%d" `+

--- a/static/index.html
+++ b/static/index.html
@@ -61,6 +61,46 @@
             });
         }
 
+        // Refresh all feeds in a specific folder in parallel, same approach as refreshAllFeeds.
+        function refreshFolderFeeds(btn, folderId) {
+            btn.disabled = true;
+            var feedIds = Array.from(
+                document.querySelectorAll('#feed-list [data-feed-id]')
+            ).filter(function(el) {
+                return el.closest('.folder-section') === btn.closest('.folder-section');
+            }).map(function(el) { return el.dataset.feedId; });
+
+            if (feedIds.length === 0) {
+                htmx.ajax('GET', '/api/ui/articles?folder_id=' + folderId, {target: '#article-list', swap: 'innerHTML'});
+                btn.disabled = false;
+                return;
+            }
+
+            var totalNew = 0;
+            var remaining = feedIds.length;
+
+            feedIds.forEach(function(id) {
+                fetch('/api/ui/feeds/' + id + '/refresh', {method: 'POST'})
+                    .then(function(resp) {
+                        var msg = resp.headers.get('X-Refresh-Message') || '';
+                        var match = msg.match(/^(\d+)/);
+                        if (match) totalNew += parseInt(match[1]);
+                    })
+                    .catch(function() {})
+                    .finally(function() {
+                        if (--remaining === 0) {
+                            htmx.ajax('GET', '/api/ui/articles?folder_id=' + folderId, {target: '#article-list', swap: 'innerHTML'});
+                            showRefreshToast(
+                                totalNew === 0 ? 'Already up to date' :
+                                totalNew === 1 ? '1 new article' :
+                                totalNew + ' new articles'
+                            );
+                            btn.disabled = false;
+                        }
+                    });
+            });
+        }
+
         // htmx:afterRequest is a built-in HTMX event guaranteed to bubble to document.
         // We check the hx-post attribute to identify refresh/subscribe requests, then
         // read the message from a plain response header (no HTMX event parsing involved).

--- a/store.go
+++ b/store.go
@@ -24,7 +24,7 @@ func openDB() (*sql.DB, error) {
 	// Run each migration. IF NOT EXISTS makes these no-ops after first run.
 	for _, migration := range []string{
 		createFeedsTable, createArticlesTable, createArticleIndexes,
-		createFoldersTable, createFeedFolderIndex,
+		createFoldersTable,
 	} {
 		if _, err := db.Exec(migration); err != nil {
 			return nil, fmt.Errorf("running migration: %w", err)
@@ -37,6 +37,11 @@ func openDB() (*sql.DB, error) {
 		if !strings.Contains(err.Error(), "duplicate column name") {
 			return nil, fmt.Errorf("running migration: %w", err)
 		}
+	}
+
+	// This index depends on folder_id existing — must run after the ALTER TABLE above.
+	if _, err := db.Exec(createFeedFolderIndex); err != nil {
+		return nil, fmt.Errorf("running migration: %w", err)
 	}
 
 	return db, nil

--- a/ui.go
+++ b/ui.go
@@ -232,45 +232,6 @@ func uiToggleReadHandler(w http.ResponseWriter, r *http.Request, path string) {
 	writeHTML(w, http.StatusOK, renderOneArticle(article))
 }
 
-// uiRefreshFolderHandler refreshes all feeds in a folder and returns their articles.
-// POST /api/ui/folders/:id/refresh
-func uiRefreshFolderHandler(w http.ResponseWriter, r *http.Request, path string) {
-	id := parseFolderIDFromRefresh(path)
-	if id == -1 {
-		http.NotFound(w, r)
-		return
-	}
-
-	db, err := openDB()
-	if err != nil {
-		writeHTML(w, http.StatusInternalServerError, `<p class="error">Database error</p>`)
-		return
-	}
-
-	feeds, err := listFeedsByFolder(db, id)
-	if err != nil {
-		writeHTML(w, http.StatusInternalServerError, `<p class="error">Failed to load feeds</p>`)
-		return
-	}
-
-	totalNew := 0
-	for i := range feeds {
-		n, _ := refreshFeed(db, &feeds[i])
-		totalNew += n
-	}
-
-	var msg string
-	if totalNew == 1 {
-		msg = "1 new article"
-	} else if totalNew > 1 {
-		msg = fmt.Sprintf("%d new articles", totalNew)
-	} else {
-		msg = "Already up to date"
-	}
-	w.Header().Set("X-Refresh-Message", msg)
-	renderArticleList(w, db, 0, id, 0)
-}
-
 // uiDeleteFolderHandler deletes a folder and returns the updated feed list.
 // Feeds in the deleted folder move to General (folder_id = NULL via ON DELETE SET NULL).
 // DELETE /api/ui/folders/:id


### PR DESCRIPTION
## Summary

- **Migration ordering bug fix** — `createFeedFolderIndex` was running before `addFolderIDToFeeds` (the ALTER TABLE), causing `openDB()` to fail on every request after deploy. Fixed by running the index after the column exists.
- **Folder refresh parallelised** — folder ↻ button now fans out per-feed requests from the browser in parallel (same pattern as "Refresh all"), instead of blocking sequential server-side iteration. Removed `uiRefreshFolderHandler`.
- **Pre-commit hook** — `.claude/settings.json` gates every `git commit` behind `go test ./... && go vet ./...`. Blocks the commit with a clear message if either fails. Would have caught the migration bug before it shipped.

## Test plan

- [ ] Subscribe to feeds and verify they appear under "General"
- [ ] Create a folder via subscribe form, verify feed lands in it
- [ ] Click a folder name — article list filters to that folder only
- [ ] Click folder ↻ — refreshes in parallel, toast shows new article count
- [ ] Move a feed via the inline select — sidebar updates immediately
- [ ] Delete a folder — feeds move to General
- [ ] Deploy to a fresh environment and verify feeds/articles load (migration ordering fix)
- [ ] Break a test intentionally, attempt `git commit` — verify it blocks

https://claude.ai/code/session_01PMkLDFCorK9rVLzNG33nNL